### PR TITLE
Hotfix: Update package.json 

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/eosdis-nasa/earthdata-pub-upload.git"
+    "url": "git+https://github.com/eosdis-nasa/earthdata-pub-upload.git"
   },
   "author": "EDPub Development Team",
   "license": "BSD 3-Clause License",
@@ -25,7 +25,12 @@
   "devDependencies": {
     "jest": "^29.7.0"
   },
-  "keywords": ["upload", "edpub", "earthdata", "nasa"],
+  "keywords": [
+    "upload",
+    "edpub",
+    "earthdata",
+    "nasa"
+  ],
   "homepage": "https://pub.earthdata.nasa.gov/",
   "bugs": {
     "url": "https://github.com/eosdis-nasa/earthdata-pub-upload/issues"


### PR DESCRIPTION
# Description

Update to avoid npm auto-corrected some errors in your package.json when publishing warning when running `npm publish`


## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Run `npm publish`
4. Ensure you don't see a warning like
```
npm auto-corrected some errors in your package.json when publishing
```